### PR TITLE
Added support to read and remove current serialized object

### DIFF
--- a/src/JMS/Serializer/GenericSerializationVisitor.php
+++ b/src/JMS/Serializer/GenericSerializationVisitor.php
@@ -159,6 +159,7 @@ abstract class GenericSerializationVisitor extends AbstractVisitor
      * @param string $key
      * @param scalar|array $value This value must either be a regular scalar, or an array.
      *                            It must not contain any objects anymore.
+     * @throws Exception\InvalidArgumentException
      */
     public function addData($key, $value)
     {
@@ -167,6 +168,31 @@ abstract class GenericSerializationVisitor extends AbstractVisitor
         }
 
         $this->data[$key] = $value;
+    }
+
+    /**
+     * Allows you to remove data from the current object/root element.
+     *
+     * @param string $key
+     * @throws Exception\InvalidArgumentException
+     */
+    public function removeData($key)
+    {
+        if (!isset($this->data[$key])) {
+            throw new InvalidArgumentException(sprintf('There is no data for "%s".', $key));
+        }
+
+        unset($this->data[$key]);
+    }
+
+    /**
+     * Returns the current object
+     *
+     * @return mixed
+     */
+    public function getData()
+    {
+        return $this->data;
     }
 
     public function getRoot()


### PR DESCRIPTION
The method addData($key, $value) allows to add new keys to serialised objects but no further manipulation to the serialised object is possible is post serialize events. This commit added the 2 methods: removeData($key) and getData(). This will allow manipulation of the current serialised object in post serialize event listeners. This is in response to #74, as I'm facing a similar need.